### PR TITLE
EXPR: move batching logic to the library

### DIFF
--- a/lib/tasks/sync_contacts.rake
+++ b/lib/tasks/sync_contacts.rake
@@ -9,9 +9,7 @@ task "salesforce:sync_contacts" => :environment do
   users = User.real
   users = users.where(approved: true) if SiteSetting.must_approve_users?
 
-  users.find_in_batches do |users_list|
-    contacts = users_list.map { |user| updater.build_contact(bulk_user: user) }
-    result = bulk_instance.create("Contact", contacts)
-    puts "result is: #{result.inspect}"
-  end
+  contacts = users.map { |user| updater.build_contact(bulk_user: user) }
+  result = bulk_instance.create("Contact", contacts, false, false, 1000)
+  puts "result is: #{result.inspect}"
 end


### PR DESCRIPTION
The batching logic was earlier being handled by rails `find_in_batches`. The problem with that approach is that it creates multiple Salesforce Bulk Jobs which run in parallel and might conflict with each other causing race conditions on the salesforce records. If this approach works with the Contact type records, we'll use it for other rake tasks as well.